### PR TITLE
called link preview from process var on heroku and added a build script

### DIFF
--- a/db/database.js
+++ b/db/database.js
@@ -1,11 +1,11 @@
 // If you're using Windows OS in development, you need to save your postgres username and password in your local .env file before starting the app
 const Sequelize = require('sequelize');
 const dotenv = require('dotenv').config().parsed;
-const platform = process.env.PLATFORM ? process.env.PLATFORM.trim() : null
 
 /***** 2 DATABSE CONNECTION OPTIONS *****/
 //1 
    // USE THIS FOR CONNECTING TO YOU LOCAL VERSION OF THE DB
+   // const platform = process.env.PLATFORM ? process.env.PLATFORM.trim() : null
    // const localConnectionString = platform === 'windows' ? `postgres://${dotenv.PSQL_USER}:${dotenv.PSQL_PW}@127.0.0.1:5432/twitchtrivia` : `postgres://localhost:5432/twitchtrivia`;
 
 //2

--- a/db/database.js
+++ b/db/database.js
@@ -1,8 +1,11 @@
-// This is the standard databse declaration for Mac OS. Not that this will break in Windows OS, where password is required
-// You will need to create a postgreSQL database on your local machine named redirect
+// If you're using Windows OS in development, you need to save your postgres username and password in your local .env file before starting the app
 const Sequelize = require('sequelize');
-const db = new Sequelize(
-  process.env.DATABASE_URL || 'postgres://localhost:5432/redirect',
+const dotenv = require('dotenv').config().parsed;
+const platform = process.env.PLATFORM ? process.env.PLATFORM.trim() : null
+const connectionString = platform === 'windows' ? `postgres://${dotenv.PSQL_USER}:${dotenv.PSQL_PW}@127.0.0.1:5432/twitchtrivia` : `postgres://localhost:5432/twitchtrivia`;
+const dbUrl =
+process.env.DATABASE_URL || connectionString;
+const db = new Sequelize(dbUrl,
   {
     logging: false,
   }

--- a/db/database.js
+++ b/db/database.js
@@ -6,7 +6,7 @@ const dotenv = require('dotenv').config().parsed;
 //1 
    // USE THIS FOR CONNECTING TO YOU LOCAL VERSION OF THE DB
    // const platform = process.env.PLATFORM ? process.env.PLATFORM.trim() : null
-   // const localConnectionString = platform === 'windows' ? `postgres://${dotenv.PSQL_USER}:${dotenv.PSQL_PW}@127.0.0.1:5432/twitchtrivia` : `postgres://localhost:5432/twitchtrivia`;
+   // const localConnectionString = platform === 'windows' ? `postgres://${dotenv.PSQL_USER}:${dotenv.PSQL_PW}@127.0.0.1:5432/redirect` : `postgres://localhost:5432/redirect`;
 
 //2
    // USE THIS FOR CONNECTING TO THE PRODUCTION DB IN HEROKU

--- a/db/database.js
+++ b/db/database.js
@@ -2,12 +2,30 @@
 const Sequelize = require('sequelize');
 const dotenv = require('dotenv').config().parsed;
 const platform = process.env.PLATFORM ? process.env.PLATFORM.trim() : null
-const connectionString = platform === 'windows' ? `postgres://${dotenv.PSQL_USER}:${dotenv.PSQL_PW}@127.0.0.1:5432/twitchtrivia` : `postgres://localhost:5432/twitchtrivia`;
+
+/***** 2 DATABSE CONNECTION OPTIONS *****/
+//1 
+   // USE THIS FOR CONNECTING TO YOU LOCAL VERSION OF THE DB
+   // const localConnectionString = platform === 'windows' ? `postgres://${dotenv.PSQL_USER}:${dotenv.PSQL_PW}@127.0.0.1:5432/twitchtrivia` : `postgres://localhost:5432/twitchtrivia`;
+
+//2
+   // USE THIS FOR CONNECTING TO THE PRODUCTION DB IN HEROKU
+   const herokuConnectionString = `postgres://${dotenv.DB_USER}:${dotenv.DB_PW}@${dotenv.DB_HOST}:${dotenv.DB_PORT}/${dotenv.DB_NAME}`
+
+/******* *******/
+
 const dbUrl =
-process.env.DATABASE_URL || connectionString;
+process.env.DATABASE_URL || herokuConnectionString;
 const db = new Sequelize(dbUrl,
   {
     logging: false,
+    dialect: "postgres",
+    dialectOptions: {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false
+      }
+    },
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon server/index.js",
     "start-nodb-mc": "SET MODE=nodatabase && SET PLATFORM=windows && nodemon server/index.js",
-    "start-nodb-mac": "MODE=nodatabase && nodemon server/index.js"
+    "start-nodb-mac": "MODE=nodatabase && nodemon server/index.js",
+    "build": "npm i"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "nodemon server/index.js",
     "start-nodb-mc": "SET MODE=nodatabase && SET PLATFORM=windows && nodemon server/index.js",
     "start-nodb-mac": "MODE=nodatabase && nodemon server/index.js",
+    "start-dev": "MODE=database && NODE_ENV=development npm run start-server",
+    "start-dev-mc": "SET MODE=database && SET NODE_ENV=development && SET PLATFORM=windows && npm run start",
     "build": "npm i"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon server/index.js",
     "start-nodb-mc": "SET MODE=nodatabase && SET PLATFORM=windows && nodemon server/index.js",
-    "start-nodb-mac": "MODE=nodatabase && nodemon server/index.js",
-    "start-dev": "MODE=database && NODE_ENV=development npm run start-server",
+    "start-nodb-mac": "NODE_ENV=development && MODE=nodatabase npm run start",
+    "start-dev": "NODE_ENV=development && MODE=database npm run start",
     "start-dev-mc": "SET MODE=database && SET NODE_ENV=development && SET PLATFORM=windows && npm run start",
     "build": "npm i"
   },

--- a/server/api/businesses.js
+++ b/server/api/businesses.js
@@ -27,10 +27,14 @@ router.get('/getThree', (req, res) => {
 });
 
 router.get('/getByCategory/:category', (req, res) => {
+  console.log('finding businesses by category');
   Business.findAll({
     where: { category: req.params.category },
   })
-    .then((Businesses) => res.json(Businesses))
+    .then((Businesses) => {
+      console.log(Businesses)
+      return res.json(Businesses)
+    })
     .catch((err) =>
       res
         .status(404)

--- a/server/api/keys.js
+++ b/server/api/keys.js
@@ -1,7 +1,7 @@
 const dotenv = require('dotenv').config().parsed;
 const router = require('express').Router();
 
-const LINK_PREVIEW_KEY = dotenv.LINK_PREVIEW_KEY
+const LINK_PREVIEW_KEY = dotenv ? dotenv.LINK_PREVIEW_KEY : process.env.LINK_PREVIEW_KEY
 
 router.get("/linkPreview", (req, res) => {
     return LINK_PREVIEW_KEY ? res.status(200).send(LINK_PREVIEW_KEY) : res.status(404).send('LINK_PREVIEW_KEY Not Found')

--- a/server/index.js
+++ b/server/index.js
@@ -2,11 +2,12 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const app = express();
 const port = process.env.PORT || 3001;
-const { startDb } = require('./utils');
+const { startDb, logRequest } = require('./utils');
 
 app.use(bodyParser.json());
 
 app.use((request, response, next) => {
+  logRequest(request);
   response.header('Access-Control-Allow-Credentials', true);
   response.header('Access-Control-Allow-Origin', '*');
   response.header('Access-Control-Allow-Methods', 'GET,HEAD,OPTIONS,POST,PUT');
@@ -38,5 +39,3 @@ if (process.env.MODE.trim() == 'nodatabase') {
     });
   });
 }
-
-

--- a/server/index.js
+++ b/server/index.js
@@ -28,7 +28,7 @@ app.get('/', (_request, response) => {
   response.json({ info: 'Redirect API - Node.js, Express, and Postgres API' });
 });
 
-if (process.env.MODE.trim() == 'nodatabase') {
+if (process.env.MODE.trim() === 'nodatabase') {
   app.listen(port, () => {
     console.log(`App running on port ${port} without database.`);
   });

--- a/server/utils.js
+++ b/server/utils.js
@@ -64,7 +64,16 @@ const startDb = () => {
     });
 };
 
+const logRequest = (request) => {
+  const { method, url, body, params } = request;
+  console.log(
+    `received ${method} request at ${url} with body = ${JSON.stringify(body)}\nparams = ${JSON.stringify(params)}`
+  );
+};
+
+
 module.exports = {
   seed,
   startDb,
+  logRequest
 };


### PR DESCRIPTION
This PR fixes minor issues in the API deployment and allows devs to run the redirect app from their local machine. Note that in order to obtain the .env variables you need to run this branch, you'll need admin privileges to the Redirect Heroku app.

Changes:
 - Added request logging
 - Added a build script so that Heroku doesn't time out while binding to a port on deployment
 - Called environment variables from process.env because dotenv was returning undefined when deployed on Heroku.
 - Added option to start the app with a database in a local development environment